### PR TITLE
Add pre-deployment and test script

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,78 @@
+# MAAP API Query Service Deployment
+### Steps
+1. Clone the repo
+2. Install `aws sam cli`:
+    ``` 
+    brew tap aws/tap
+    brew install aws-sam-cli
+    ```
+3. Install the dependencies:
+    ```
+    npm install
+4. Create `ssm` parameters for the database credentials (`host`, `name`, `username`, `password`). Read: [readme](https://github.com/MAAP-Project/maap-api-query-service#ssm).
+5. Set the environment variables
+    ```
+    `STAGE` (default: `dev`)
+    `NODE_ENV` (default: `production`)
+    `SSM_GEDI_DB_HOST` (default: `/dev/gedi-cal-val-db/host`)
+    `SSM_GEDI_DB_NAME` (default: `/dev/gedi-cal-val-db/name`)
+    `SSM_GEDI_DB_USER` (default: `/dev/gedi-cal-val-db/user`)
+    `SSM_GEDI_DB_PASS` (default: `/dev/gedi-cal-val-db/pass`)
+    ```
+6. Run full deployment (builds, packages and deploys)
+    ```
+    npm run full-deploy
+    ```
+
+### Testing the deployment
+1. Copy the `QueryStateMachineArn Value` from the above step. Looks like 
+   ```
+   arn:aws:states:us-east-1:532321095167:stateMachine:maap-api-query-service-dev-RunQuery
+   ```
+2. Run:
+   ```
+    npm run test-deployment <QueryStateMachineArn>
+    ```
+
+#### Note:
+The test script `/scripts/test-deployment.js` uses the following input for the step function:
+```
+{
+  "id": <Programatically generated uniqueId>,
+  "src": {
+    "Collection": {
+      "ShortName": "GEDI Cal/Val Field Data_1",
+      "VersionId": "001"
+    }
+  },
+  "query": {
+    "where": {
+      "project": "usa_sonoma"
+    },
+    "bbox": [
+      -122.6,
+      38.4,
+      -122.5,
+      38.5
+    ],
+    "fields": ["project", "latitude", "longitude"],
+    "table":"tree"
+  }
+}
+```
+The output looks something like:
+```
+[
+  {
+    project: 'usa_sonoma',
+    latitude: 38.4673410250767,
+    longitude: -122.560555589317
+  },
+  {
+    project: 'usa_sonoma',
+    latitude: 38.4643964460817,
+    longitude: -122.570924053867
+  },
+  ...
+]
+```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,7 +27,7 @@
 ### Testing the deployment
 1. Copy the `QueryStateMachineArn Value` from the above step. Looks like 
    ```
-   arn:aws:states:us-east-1:532321095167:stateMachine:maap-api-query-service-dev-RunQuery
+   arn:aws:states:us-east-1:XXXXXXXXXXXX:stateMachine:maap-api-query-service-dev-RunQuery
    ```
 2. Run:
    ```

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "start": "tsc --watch",
     "build": "NODE_ENV=${NODE_ENV:-production} npm run clean && tsc && cp package.json dist && npm install --prefix dist/ --production",
     "validate": "node scripts/validate-template.js",
+    "prepackage": "node scripts/prepare-deployment.js $npm_package_name ${STAGE:-dev}",
     "package": "npm run --silent validate && sam package --template-file template.yaml --s3-bucket $npm_package_name-${STAGE:-dev} --output-template-file template.packaged.yaml",
-    "deploy": "sam deploy --template-file template.packaged.yaml --stack-name $npm_package_name-${STAGE:-dev} --capabilities CAPABILITY_IAM --parameter-override Stage=${STAGE:-dev} GediDatabaseHost=\"${SSM_GEDI_DB_HOST:-/dev/gedi-cal-val-db/host}\" GediDatabaseName=\"${SSM_GEDI_DB_NAME:-/dev/gedi-cal-val-db/name}\" GediDatabaseUser=\"${SSM_GEDI_DB_USER:-/dev/gedi-cal-val-db/user}\" GediDatabasePass=\"${SSM_GEDI_DB_PASS:-/dev/gedi-cal-val-db/pass}\"  --no-fail-on-empty-changeset --s3-bucket $npm_package_name-${STAGE:-dev}-deploy",
+    "deploy": "sam deploy --template-file template.packaged.yaml --stack-name $npm_package_name-${STAGE:-dev} --capabilities CAPABILITY_IAM --parameter-overrides Stage=${STAGE:-dev} GediDatabaseHost=\"${SSM_GEDI_DB_HOST:-/dev/gedi-cal-val-db/host}\" GediDatabaseName=\"${SSM_GEDI_DB_NAME:-/dev/gedi-cal-val-db/name}\" GediDatabaseUser=\"${SSM_GEDI_DB_USER:-/dev/gedi-cal-val-db/user}\" GediDatabasePass=\"${SSM_GEDI_DB_PASS:-/dev/gedi-cal-val-db/pass}\"  --no-fail-on-empty-changeset --s3-bucket $npm_package_name-${STAGE:-dev}-deploy",
     "full-deploy": "npm run build && npm run package && npm run deploy",
+    "test-deployment": "node scripts/test-deployment $npm_package_name ${STAGE:-dev}",
     "describe-stack": "aws cloudformation describe-stacks --stack-name $npm_package_name-${STAGE:-dev}",
     "describe-stack-events": "aws cloudformation describe-stack-events --stack-name $npm_package_name-${STAGE:-dev}",
     "clean": "rm -rf dist/*"

--- a/scripts/prepare-deployment.js
+++ b/scripts/prepare-deployment.js
@@ -21,7 +21,7 @@ params.forEach((param) => {
       } else {
         console.log(`Created bucket ${param.Bucket}`);
       }
-    })yar
+    })
   } else {
     console.log(`${param.Bucket} exists`);
   }

--- a/scripts/prepare-deployment.js
+++ b/scripts/prepare-deployment.js
@@ -1,7 +1,9 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
-
+/*
+  This scripts creates the two s3 buckets required by the `package` and `deploy` scripts
+*/
 const npm_package_name = process.argv[2];
 const stage = process.argv[3];
 

--- a/scripts/prepare-deployment.js
+++ b/scripts/prepare-deployment.js
@@ -1,0 +1,29 @@
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+
+
+const npm_package_name = process.argv[2];
+const stage = process.argv[3];
+
+var params = [{
+  Bucket: `${npm_package_name}-${stage}`
+}, {
+  Bucket: `${npm_package_name}-${stage}-deploy`
+}]
+
+params.forEach((param) => {
+  s3.headBucket(param, function(err, data) {
+  if (err) {
+    s3.createBucket(param, function(err, data) {
+      if (err) {
+        console.log(err);
+        console.log(`Error creating bucket ${param.Bucket}`);
+      } else {
+        console.log(`Created bucket ${param.Bucket}`);
+      }
+    })yar
+  } else {
+    console.log(`${param.Bucket} exists`);
+  }
+})
+});

--- a/scripts/test-deployment.js
+++ b/scripts/test-deployment.js
@@ -1,0 +1,46 @@
+const AWS = require('aws-sdk');
+
+async function test() {
+  const region = process.argv[4].split(':')[3];
+  console.log(region);
+  const stepfunctions = new AWS.StepFunctions({
+    region: region
+  });
+  const s3 = new AWS.S3();
+  const currentDateTime = new Date().toISOString();
+  const uniqueId = `testdeployment-${currentDateTime}`.replace(/[^a-zA-Z0-9]/g, "")
+  const params = {
+    stateMachineArn: process.argv[4],
+    name: uniqueId,
+    input: JSON.stringify(process.argv[5]),
+  }
+  
+  const success = await stepfunctions.startExecution(params).promise();
+  console.log(`Successfully executed stepfunction: ${success.executionArn}`);
+  
+  const npm_package_name = process.argv[2];
+  const stage = process.argv[3];
+  var param = {
+    Bucket: `${npm_package_name}-${stage}-query-results`,
+    Key: uniqueId
+  };
+  
+  console.log("Waiting to get result of the query");
+  await new Promise(resolve => setTimeout(resolve, 9000));
+
+  s3.getObject(param, function(err, data)
+  {
+    if (!err)
+      console.log(JSON.parse(data.Body.toString()));
+    else {
+      console.log('Error while reading output')
+    }
+  });
+}
+
+try {
+  test();
+} catch (e) {
+
+  console.log(e.message);
+}

--- a/scripts/test-deployment.js
+++ b/scripts/test-deployment.js
@@ -1,8 +1,34 @@
 const AWS = require('aws-sdk');
 
+// Command: node test-deployment [npm_package_name] [stage] [state_machine_arn]
+/*
+  Tests the deployment by running the created statemachine with a arbitrary input
+  The input is: 
+  {
+    "id": <programatically generated uniqueId>,
+    "src": {
+      "Collection": {
+        "ShortName": "GEDI Cal/Val Field Data_1",
+        "VersionId": "001"
+      }
+    },
+    "query": {
+      "where": {
+        "project": "usa_sonoma"
+      },
+      "bbox": [
+        -122.6,
+        38.4,
+        -122.5,
+        38.5
+      ],
+      "fields": ["project", "latitude", "longitude"],
+      "table":"tree"
+    }
+  }
+*/
 async function test() {
-  const region = process.argv[4].split(':')[3];
-  console.log(region);
+  const region = process.argv[4].split(':')[3]; // Extracts the region from the stepfunction arn
   const stepfunctions = new AWS.StepFunctions({
     region: region
   });
@@ -46,9 +72,11 @@ async function test() {
     Key: uniqueId
   };
   
+  // Waits some time to allow the result to be written to the s3 bucket
   console.log("Waiting to get result of the query");
   await new Promise(resolve => setTimeout(resolve, 9000));
 
+  // Reads the result from the QueryResults s3 bucket
   s3.getObject(param, function(err, data)
   {
     if (!err)
@@ -62,6 +90,5 @@ async function test() {
 try {
   test();
 } catch (e) {
-
   console.log(e.message);
 }

--- a/scripts/test-deployment.js
+++ b/scripts/test-deployment.js
@@ -12,7 +12,28 @@ async function test() {
   const params = {
     stateMachineArn: process.argv[4],
     name: uniqueId,
-    input: JSON.stringify(process.argv[5]),
+    input: JSON.stringify({
+      "id": uniqueId,
+      "src": {
+        "Collection": {
+          "ShortName": "GEDI Cal/Val Field Data_1",
+          "VersionId": "001"
+        }
+      },
+      "query": {
+        "where": {
+          "project": "usa_sonoma"
+        },
+        "bbox": [
+          -122.6,
+          38.4,
+          -122.5,
+          38.5
+        ],
+        "fields": ["project", "latitude", "longitude"],
+        "table":"tree"
+      }
+    }),
   }
   
   const success = await stepfunctions.startExecution(params).promise();

--- a/template.yaml
+++ b/template.yaml
@@ -206,16 +206,8 @@ Resources:
         Rules:
           - ExpirationInDays: 7
             Status: Enabled
-# Outputs:
-#   RatePlansTable:
-#     Description: RatePlansTable table name
-#     Value: !Ref RatePlansTable
-#   PackerStateMachineArn:
-#     Description: PackerStateMachine ARN
-#     Value: !Ref PackerStateMachine
-#   CheckForNewUsageStateMachineArn:
-#     Description: CheckForNewUsageStateMachine ARN
-#     Value: !Ref CheckForNewUsageStateMachine
-#   FetchPlansStateMachineArn:
-#     Description: FetchPlansStateMachine ARN
-#     Value: !Ref FetchPlansStateMachine
+
+Outputs:
+  QueryStateMachineArn:
+    Description: Query State Machine ARN
+    Value: !GetAtt RunQuery.Arn


### PR DESCRIPTION
This PR adds the following:
1. Adds a pre-deployment script that automatically creates the s3 buckets required by the deployment
2. A post-deployment test script that takes in the `arn` of the created `Query State Machine`, and tests if it's running by supplying an input object and checking the output of the execution.

The steps for deployment and testing are presented in the `[DEPLOYMENT.md](https://github.com/MAAP-Project/maap-api-query-service/blob/slesa/add_deployment_test_script/DEPLOYMENT.md)` file.

Related issue: https://github.com/MAAP-Project/ZenHub/issues/299